### PR TITLE
Update isHeaderMatch() regex to catch errors

### DIFF
--- a/stream.php
+++ b/stream.php
@@ -277,7 +277,7 @@ function send($full_json_message) {
   }
 
 	private function isHeaderMatch($subject) {
-	if (preg_match("/<message to=\".*.\" from=\".*.\" type=\".*.\">/", $subject)) {
+	if (preg_match("/<message to=\".*.\" from=\".*.\" type=\".*.\">/", $subject) || preg_match("/<message>/", $subject)) {
 		return true;
 	} else {
 		return false;


### PR DESCRIPTION
Update the isHeaderMatch(); regex in order to catch errors too such as bad tokens. 

For example, send a message with a bad token will provoques the following error :
`<message><data:gcm xmlns:data="google:mobile:data">{"message_type":"nack","from":"wrong_token","message_id":"event4879","error":"BAD_REGISTRATION","error_description":""}</data:gcm></message>`

The previous regex `<message to=\".*.\" from=\".*.\" type=\".*.\">` didn't catch this error, making isHeaderMatch(); returning false and consequently never accessing to the line 150.